### PR TITLE
Fix super in WirelessListModel __init__

### DIFF
--- a/ui/model/wireless_list_model.py
+++ b/ui/model/wireless_list_model.py
@@ -13,7 +13,7 @@ class WirelessListModel(QAbstractItemModel):
         Initialize our abstract item model by calling the super class
         initializer and with an empty list of elements.
         '''
-        QAbstractItemModel.__init__(self, parent, *args)
+        super().__init__(parent, *args)
         self.items = []
 
     def index(self, row, column, parent=QModelIndex()):


### PR DESCRIPTION
This change fixes the call to `__init__` for the super object :)